### PR TITLE
getsvgspriteを使用して外部スプライト参照する場合はHTMLコードにSVGタグを保持しておく必要がないので削除

### DIFF
--- a/resources/themes/lig-wordpress-template/assets/css/04_pages/00_global/_00_base.scss
+++ b/resources/themes/lig-wordpress-template/assets/css/04_pages/00_global/_00_base.scss
@@ -1,12 +1,3 @@
 html {
   @include font();
 }
-
-[data-svg-sprite] {
-  display: none;
-}
-
-.svg-sprite {
-  width: 100%;
-  height: 100%;
-}

--- a/wp/wp-content/themes/lig-wordpress-template/header.php
+++ b/wp/wp-content/themes/lig-wordpress-template/header.php
@@ -9,5 +9,4 @@
     <?php wp_head(); ?>
 </head>
 <body id="body" <?php body_class(); ?>>
-<?= file_get_contents(PATH_SVG_SPRITE); ?>
 <?php import_part('header') ?>


### PR DESCRIPTION
getsvgspriteを使用して外部スプライト参照する場合はHTMLコード内にSVGタグを保持しておく必要がないのでテンプレートから削除しておきたいです。